### PR TITLE
Adds tox.ini and basic rock test

### DIFF
--- a/.copyright.tmpl
+++ b/.copyright.tmpl
@@ -1,0 +1,2 @@
+Copyright ${years} ${owner}.
+See LICENSE file for licensing details

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==24.3.0
+codespell==2.2.4
+flake8==6.0.0
+isort==5.12.0
+licenseheaders==0.8.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+coverage[toml]==7.2.5
+pytest==7.3.1
+PyYAML==6.0.1
+tenacity==8.2.3

--- a/tests/sanity/test_whereabouts.py
+++ b/tests/sanity/test_whereabouts.py
@@ -1,0 +1,63 @@
+#
+# Copyright 2024 Canonical, Ltd.
+# See LICENSE file for licensing details
+#
+
+import pathlib
+import subprocess
+
+import pytest
+import yaml
+
+ROCK_EXPECTED_FILES = [
+    "/install-cni.sh",
+    "/ip-control-loop",
+    "/whereabouts",
+]
+
+METADATA = yaml.safe_load(pathlib.Path("./rockcraft.yaml").read_text())
+# Assuming rock name is the same as application name.
+ROCK_NAME = METADATA["name"]
+VERSION = METADATA["version"]
+LOCAL_ROCK_IMAGE = f"{ROCK_NAME}:{VERSION}"
+
+
+def _run_in_docker(check_exit_code, *command):
+    return subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-i",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            *command,
+        ],
+        check=check_exit_code,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_whereabouts_rock():
+    """Test Whereabouts rock."""
+    # check rock filesystem
+    _run_in_docker(True, "ls", "-la", *ROCK_EXPECTED_FILES)
+
+    # check binary name and version.
+    process = _run_in_docker(True, f"/{ROCK_NAME}", "version")
+    output = process.stderr
+    assert ROCK_NAME in output and VERSION in output
+
+    # check other binary. It expects KUBERNETES_SERVICE_HOST to be defined.
+    process = _run_in_docker(False, "/ip-control-loop")
+    assert "KUBERNETES_SERVICE_HOST" in process.stderr
+
+    # check script. It expects serviceaccount token to exist.
+    process = _run_in_docker(False, "/install-cni.sh")
+    expected_error = (
+        "cat: /var/run/secrets/kubernetes.io/serviceaccount/token: "
+        "No such file or directory"
+    )
+    assert expected_error == process.stderr.strip()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,68 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+no_package = True
+skip_missing_interpreters = True
+#envlist = format, lint, sanity, integration, pack, export-to-docker
+envlist = format, lint, sanity, integration
+min_version = 4.0.0
+
+[testenv]
+setenv =
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+
+[testenv:format]
+description = Apply coding style standards to code
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/tests
+    isort {toxinidir}/tests --profile=black
+    black {toxinidir}/tests
+
+[testenv:lint]
+description = Check code against coding style standards
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    codespell {tox_root}/tests
+    flake8 {tox_root}/tests
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/tests --dry
+    isort {tox_root}/tests --profile=black --check
+    black {tox_root}/tests --check --diff
+
+[testenv:sanity]
+description = Run sanity tests
+passenv = *
+deps = -r {tox_root}/requirements-test.txt
+commands =
+    pytest -v \
+        --maxfail 1 \
+        --tb native \
+        --log-cli-level DEBUG \
+        --disable-warnings \
+        {posargs} \
+        {tox_root}/tests/sanity
+pass_env =
+    TEST_*
+    ROCK_*
+
+[testenv:integration]
+description = Run integration tests
+deps = -r {tox_root}/requirements-test.txt
+commands =
+    echo "WARNING: This is a placeholder test - no test is implemented here."
+pass_env =
+    TEST_*
+    ROCK_*
+
+[flake8]
+max-line-length = 120
+select = E,W,F,C,N
+# E231: missing whitespace after ':'
+# E231 excluded for false positives in strings and fstrings.
+ignore = W503,E231
+exclude = venv,.git,.tox,.tox_env,.venv,build,dist,*.egg_info
+show-source = true


### PR DESCRIPTION
Adds the following tox targets: fmt, lint, sanity, integration.

Adds basic rock test, checking that the expected files exist in the rock, and checking the added executables outputs.