### PR TITLE
Adds integration test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,5 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+pytest_plugins = ["k8s_test_harness.plugin"]

--- a/tests/integration/test_whereabouts.py
+++ b/tests/integration/test_whereabouts.py
@@ -2,6 +2,62 @@
 # Copyright 2024 Canonical, Ltd.
 #
 
+import logging
+from pathlib import Path
 
-def test_integration_whereabouts():
-    assert False, "Integration tests are not yet implemented yet"
+from k8s_test_harness import harness
+from k8s_test_harness.util import env_util, k8s_util
+
+LOG = logging.getLogger(__name__)
+
+DIR = Path(__file__).absolute().parent
+MANIFESTS_DIR = DIR / ".." / "templates"
+
+
+def _get_whereabouts_helm_cmd():
+    whereabouts_rock = env_util.get_build_meta_info_for_rock_version(
+        "whereabouts", "0.6.3", "amd64"
+    )
+    rock_image = whereabouts_rock.image
+
+    # This helm chart requires the registry to be separated from the image.
+    registry = "docker.io"
+    parts = rock_image.split("/")
+    if len(parts) > 1:
+        registry = parts[0]
+        rock_image = parts[1]
+
+    images = [
+        k8s_util.HelmImage(rock_image),
+    ]
+
+    return k8s_util.get_helm_install_command(
+        "whereabouts",
+        "oci://registry-1.docker.io/bitnamicharts/whereabouts",
+        "whereabouts",
+        images=images,
+        set_configs=[f"image.registry={registry}"],
+    )
+
+
+def test_integration_whereabouts(module_instance: harness.Instance):
+    # We also need multus in order to test out whereabouts.
+    # It should become Available if everything is fine with it.
+    helm_cmd = k8s_util.get_helm_install_command(
+        "multus", "oci://registry-1.docker.io/bitnamicharts/multus-cni"
+    )
+    module_instance.exec(helm_cmd)
+    k8s_util.wait_for_daemonset(module_instance, "multus-multus-cni", "kube-system")
+
+    module_instance.exec(_get_whereabouts_helm_cmd())
+    k8s_util.wait_for_daemonset(module_instance, "whereabouts", "whereabouts")
+
+    # Create a NetworkAttachmentDefinition and a deployment requiring it.
+    for filename in ["whereabouts-net-definition.yaml", "deployment.yaml"]:
+        manifest = MANIFESTS_DIR / filename
+        module_instance.exec(
+            ["k8s", "kubectl", "apply", "-f", "-"],
+            input=Path(manifest).read_bytes(),
+        )
+
+    k8s_util.wait_for_deployment(module_instance, "netshoot-deployment")

--- a/tests/templates/deployment.yaml
+++ b/tests/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netshoot-deployment
+  labels:
+    app: netshoot-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: netshoot-pod
+  template:
+    metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: whereabouts-conf
+      labels:
+        app: netshoot-pod
+    spec:
+      containers:
+      - name: netshoot
+        image: nicolaka/netshoot
+        command:
+          - sleep
+          - "3600"
+        imagePullPolicy: IfNotPresent

--- a/tests/templates/whereabouts-net-definition.yaml
+++ b/tests/templates/whereabouts-net-definition.yaml
@@ -1,0 +1,22 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: whereabouts-conf
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "plugins": [
+      {
+      "type": "macvlan",
+      "capabilities": { "ips": true },
+      "master": "eth0",
+      "mode": "bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.20.0/24",
+        "range_start": "192.168.20.10",
+        "range_end": "192.168.20.100",
+        "gateway": "192.168.20.1"
+        }
+      } ]
+    }'

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -49,11 +49,20 @@ pass_env =
     BUILT_ROCKS_METADATA
 
 [testenv: integration]
-allowlist_externals =
-    echo
+description = Run integration tests
+deps = -r {tox_root}/requirements-test.txt
 commands =
-# TODO: Implement integration tests here
-    echo "WARNING: This is a placeholder test - no test is implemented here."
+    pytest -v \
+        --maxfail 1 \
+        --tb native \
+        --log-cli-level DEBUG \
+        --disable-warnings \
+        {posargs} \
+        {tox_root}/integration
+pass_env =
+    TEST_*
+    ROCK_*
+    BUILT_ROCKS_METADATA
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Whereabouts depends on Multus, which means that the integration test is deploying Multus as well.

Depends-On: https://github.com/canonical/whereabouts-rock/pull/8
Depends-On: https://github.com/canonical/k8s-test-harness/pull/9
Depends-On: https://github.com/canonical/k8s-test-harness/pull/10