### PR TITLE
Adds /host folder in the rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,3 +41,10 @@ parts:
       bash -x "hack/build-go.sh"
       cp bin/* "${CRAFT_PART_INSTALL}/"
       cp script/install-cni.sh "${CRAFT_PART_INSTALL}/"
+
+  bitnami-compatibility:
+    plugin: nil
+    override-build: |
+      # install-cni.sh requires this folder to exist.
+      mkdir -p "${CRAFT_PART_INSTALL}/bitnami/whereabouts/host"
+      ln -sf /bitnami/whereabouts/host "${CRAFT_PART_INSTALL}/host"

--- a/tests/sanity/test_whereabouts.py
+++ b/tests/sanity/test_whereabouts.py
@@ -7,6 +7,7 @@ import subprocess
 import pytest
 
 ROCK_EXPECTED_FILES = [
+    "/host",
     "/install-cni.sh",
     "/ip-control-loop",
     "/whereabouts",


### PR DESCRIPTION
The ``/install-cni.sh`` script requires this folder. It does mkdir it, but the bitnami helm chart creates the daemonsets with read-only filesystem, making it impossible to create the folder.