### PR TITLE
Changes rock bases to bare

### DIFF
--- a/0.5.4/rockcraft.yaml
+++ b/0.5.4/rockcraft.yaml
@@ -7,7 +7,7 @@ description: |
 license: Apache-2.0
 version: 0.5.4
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 
 platforms:
@@ -33,6 +33,12 @@ parts:
     source-type: git
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
+    stage-packages:
+      - bash
+      - coreutils
+      - sed
+      # Needed for pgrep, which is used as a liveness / readiness probe.
+      - procps
     build-snaps:
       - go/1.16/stable
     build-environment:

--- a/0.6.1/rockcraft.yaml
+++ b/0.6.1/rockcraft.yaml
@@ -7,7 +7,7 @@ description: |
 license: Apache-2.0
 version: 0.6.1
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 
 platforms:
@@ -33,6 +33,12 @@ parts:
     source-type: git
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
+    stage-packages:
+      - bash
+      - coreutils
+      - sed
+      # Needed for pgrep, which is used as a liveness / readiness probe.
+      - procps
     build-snaps:
       - go/1.19/stable
     build-environment:

--- a/0.6.3/rockcraft.yaml
+++ b/0.6.3/rockcraft.yaml
@@ -7,7 +7,7 @@ description: |
 license: Apache-2.0
 version: 0.6.3
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
 
 platforms:
@@ -33,6 +33,12 @@ parts:
     source-type: git
     source-tag: v${CRAFT_PROJECT_VERSION}
     source-depth: 1
+    stage-packages:
+      - bash
+      - coreutils
+      - sed
+      # Needed for pgrep, which is used as a liveness / readiness probe.
+      - procps
     build-snaps:
       - go/1.20/stable
     build-environment:

--- a/tests/integration/test_whereabouts.py
+++ b/tests/integration/test_whereabouts.py
@@ -56,6 +56,16 @@ def test_integration_whereabouts(
     function_instance.exec(_get_whereabouts_helm_cmd(whereabouts_version))
     k8s_util.wait_for_daemonset(function_instance, "whereabouts", "whereabouts")
 
+    # Sanity check: make sure there isn't an error in Pebble that it couldn't start the service.
+    process = function_instance.exec(
+        ["k8s", "kubectl", "logs", "-n", "whereabouts", "daemonset.apps/whereabouts"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert '(Start service "install-cni") failed' not in process.stdout
+
     # Create a NetworkAttachmentDefinition and a deployment requiring it.
     for filename in ["whereabouts-net-definition.yaml", "deployment.yaml"]:
         manifest = MANIFESTS_DIR / filename

--- a/tests/sanity/test_whereabouts.py
+++ b/tests/sanity/test_whereabouts.py
@@ -20,7 +20,7 @@ def _test_whereabouts_rock(image_version, expected_files):
     image = rock.image
 
     # check rock filesystem
-    docker_util.ensure_image_contains_paths(image, expected_files)
+    docker_util.ensure_image_contains_paths_bare(image, expected_files)
 
     # check binary name and version.
     version = docker_util.get_image_version(image)
@@ -33,7 +33,7 @@ def _test_whereabouts_rock(image_version, expected_files):
     assert "KUBERNETES_SERVICE_HOST" in process.stderr
 
     # check script. It expects serviceaccount token to exist.
-    process = docker_util.run_in_docker(image, ["/install-cni.sh"], False)
+    process = docker_util.run_in_docker(image, ["bash", "-x", "/install-cni.sh"], False)
     assert (
         "cat: /var/run/secrets/kubernetes.io/serviceaccount/token: No such file or directory"
         in process.stderr

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -35,8 +35,10 @@ commands =
 description = Run integration tests
 deps =
     -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

The whereabouts image is supposed to install the binaries on the host it's running on. For this, it runs a bash script, which is why we still need a few stage packages. Note that the helm chart uses ``pgrep`` in a readiness / liveness probe.

We can no longer use ensure_image_contains_paths to check if files exist in the rock images, since they are now bare-based. Instead, we can use ``ensure_image_contains_paths_bare``, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.

Adds an extra sanity check during the integration tests, making sure that there is no error reported in Pebble while starting the service.

Depends-On: https://github.com/canonical/k8s-test-harness/pull/36